### PR TITLE
feat: Add IP-based rate limiting via Upstash Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,9 @@
 # Set this in Vercel dashboard (Settings > Environment Variables)
 # NEVER prefix with VITE_ — this must stay server-side only
 OPENAI_API_KEY=sk-your-key-here
+
+# Upstash Redis — required for rate limiting
+# Create a free database at https://console.upstash.com
+# Set these in Vercel dashboard (Settings > Environment Variables)
+UPSTASH_REDIS_REST_URL=https://your-database.upstash.io
+UPSTASH_REDIS_REST_TOKEN=AXxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.36.2",
         "ai": "^6.0.101",
         "bootstrap": "^5.3.8",
         "react": "^19.2.0",
@@ -1666,6 +1668,39 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.36.2",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.36.2.tgz",
+      "integrity": "sha512-C0Yt8hc12vLaQYRG1fMci8iPrLtnTdbJG0HR5T8vKnvEP/1RdMMblsOJs5/jp0JXZJ1oSzMnQz4J9EVezNpI6A==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vercel/oidc": {
       "version": "3.1.0",
@@ -3503,6 +3538,12 @@
         "react": ">=15.0.0"
       }
     },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -4852,6 +4893,30 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
+    "@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "requires": {
+        "@upstash/redis": "^1.28.3"
+      }
+    },
+    "@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "requires": {
+        "@upstash/core-analytics": "^0.0.10"
+      }
+    },
+    "@upstash/redis": {
+      "version": "1.36.2",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.36.2.tgz",
+      "integrity": "sha512-C0Yt8hc12vLaQYRG1fMci8iPrLtnTdbJG0HR5T8vKnvEP/1RdMMblsOJs5/jp0JXZJ1oSzMnQz4J9EVezNpI6A==",
+      "requires": {
+        "uncrypto": "^0.1.3"
+      }
+    },
     "@vercel/oidc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
@@ -5971,6 +6036,11 @@
         "invariant": "^2.2.4",
         "react-lifecycles-compat": "^3.0.4"
       }
+    },
+    "uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
     },
     "undici-types": {
       "version": "7.18.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.36.2",
     "ai": "^6.0.101",
     "bootstrap": "^5.3.8",
     "react": "^19.2.0",

--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -313,8 +313,9 @@ const Chat = () => {
 
           {error && (
             <div className="chat_error">
-              Something went wrong. Please try again or email Sheraz at
-              hiresheraz@gmail.com
+              {error.message?.includes('too quickly') || error.status === 429
+                ? "You're sending messages too quickly. Please wait a moment and try again."
+                : "Something went wrong. Please try again or email Sheraz at hiresheraz@gmail.com"}
             </div>
           )}
         </div>


### PR DESCRIPTION
Protect /api/chat endpoint from abuse using @upstash/ratelimit with sliding window algorithm (10 requests per 60 seconds per IP). Returns 429 with rate limit headers when exceeded. Chat UI shows specific message for rate-limited users.