### PR TITLE
feat: Redesign GitHub heatmap section and add Book a Call CTA to hero

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^19.2.0",
         "react-bootstrap": "^2.10.10",
         "react-dom": "^19.2.4",
+        "react-github-calendar": "^5.0.5",
         "react-markdown": "^10.1.0",
         "react-router": "^7.13.1",
         "web-vitals": "^5.1.0"
@@ -875,6 +876,59 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
+      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
+      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.4",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.18",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.18.tgz",
+      "integrity": "sha512-xJWJxvmy3a05j643gQt+pRbht5XnTlGpsEsAPnMi5F5YTOEEJymA90uZKBD8OvIv5XvZ1qi4GcccSlqT3Bq44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.7",
+        "@floating-ui/utils": "^0.2.10",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
+      "integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -1974,6 +2028,16 @@
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
       "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -3134,6 +3198,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-activity-calendar": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-activity-calendar/-/react-activity-calendar-3.1.1.tgz",
+      "integrity": "sha512-YvHNS4anlW3Xy0fxOU2ZTWrJkOt0ALxX8IfgDRg6jr/vgYsbh//4djf2c7CPhYNROh+5oYZzR0EJaPbrFUj2tA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.12",
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-bootstrap": {
       "version": "2.10.10",
       "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.10.tgz",
@@ -3175,6 +3252,18 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-github-calendar": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/react-github-calendar/-/react-github-calendar-5.0.5.tgz",
+      "integrity": "sha512-eZ7aSI626nY9ni/lr7ygkqD6c2adPKRb+hr7yzF+BKxKs0VBJ2FPC0EFRthk8mQQSlfzTJrbUA/uR2/ZOIAs0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-activity-calendar": "^3.0.6"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-is": {
@@ -3408,6 +3497,12 @@
       "peerDependencies": {
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
     },
     "node_modules/terser": {
       "version": "5.44.0",
@@ -4370,6 +4465,46 @@
       "dev": true,
       "optional": true
     },
+    "@floating-ui/core": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
+      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+      "requires": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "@floating-ui/dom": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
+      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "requires": {
+        "@floating-ui/core": "^1.7.4",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "@floating-ui/react": {
+      "version": "0.27.18",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.18.tgz",
+      "integrity": "sha512-xJWJxvmy3a05j643gQt+pRbht5XnTlGpsEsAPnMi5F5YTOEEJymA90uZKBD8OvIv5XvZ1qi4GcccSlqT3Bq44Q==",
+      "requires": {
+        "@floating-ui/react-dom": "^2.1.7",
+        "@floating-ui/utils": "^0.2.10",
+        "tabbable": "^6.0.0"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
+      "integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
+      "requires": {
+        "@floating-ui/dom": "^1.7.5"
+      }
+    },
+    "@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
+    },
     "@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -5062,6 +5197,11 @@
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
       "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
+    },
+    "date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
     },
     "debug": {
       "version": "4.3.4",
@@ -5763,6 +5903,15 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="
     },
+    "react-activity-calendar": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-activity-calendar/-/react-activity-calendar-3.1.1.tgz",
+      "integrity": "sha512-YvHNS4anlW3Xy0fxOU2ZTWrJkOt0ALxX8IfgDRg6jr/vgYsbh//4djf2c7CPhYNROh+5oYZzR0EJaPbrFUj2tA==",
+      "requires": {
+        "@floating-ui/react": "^0.27.12",
+        "date-fns": "^4.1.0"
+      }
+    },
     "react-bootstrap": {
       "version": "2.10.10",
       "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.10.tgz",
@@ -5789,6 +5938,14 @@
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "requires": {
         "scheduler": "^0.27.0"
+      }
+    },
+    "react-github-calendar": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/react-github-calendar/-/react-github-calendar-5.0.5.tgz",
+      "integrity": "sha512-eZ7aSI626nY9ni/lr7ygkqD6c2adPKRb+hr7yzF+BKxKs0VBJ2FPC0EFRthk8mQQSlfzTJrbUA/uR2/ZOIAs0Q==",
+      "requires": {
+        "react-activity-calendar": "^3.0.6"
       }
     },
     "react-is": {
@@ -5956,6 +6113,11 @@
         "dequal": "^2.0.3",
         "use-sync-external-store": "^1.6.0"
       }
+    },
+    "tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="
     },
     "terser": {
       "version": "5.44.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "^19.2.0",
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.2.4",
+    "react-github-calendar": "^5.0.5",
     "react-markdown": "^10.1.0",
     "react-router": "^7.13.1",
     "web-vitals": "^5.1.0"

--- a/src/Layout/App.css
+++ b/src/Layout/App.css
@@ -1427,6 +1427,89 @@ a:focus,
 }
 
 
+/* Calendar Booking Button */
+.hero_btns .chat.calendar_btn {
+    background: transparent;
+    color: var(--chakra-colors-blue-200);
+    border: 1px solid var(--chakra-colors-blue-200);
+}
+
+.hero_btns .chat.calendar_btn:hover {
+    background: var(--chakra-colors-blue-200);
+    color: var(--chakra-colors-gray-800);
+}
+
+/* GitHub Activity Section */
+.github_activity_section {
+    padding: 3rem 0 2rem;
+}
+
+.github_activity_title {
+    font-family: var(--chakra-fonts-heading);
+    font-weight: var(--chakra-fontWeights-bold);
+    font-size: var(--chakra-fontSizes-2xl);
+    line-height: 1.2;
+    margin-bottom: 1.5rem;
+}
+
+.github_stats_row {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.github_stat_card {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 1rem 0.75rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    transition: background 0.2s, border-color 0.2s;
+}
+
+.github_stat_card:hover {
+    background: rgba(255, 255, 255, 0.07);
+    border-color: rgba(88, 166, 255, 0.3);
+}
+
+.github_stat_value {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #58a6ff;
+    line-height: 1.2;
+}
+
+.github_stat_label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.7;
+    margin-top: 0.25rem;
+}
+
+.github_calendar_wrapper {
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+}
+
+@media (max-width: 576px) {
+    .github_stats_row {
+        gap: 0.5rem;
+    }
+    .github_stat_value {
+        font-size: 1.25rem;
+    }
+    .github_stat_label {
+        font-size: 0.7rem;
+    }
+    .github_stat_card {
+        padding: 0.75rem 0.5rem;
+    }
+}
+
 /* Footer Ends */
 
 
@@ -1476,6 +1559,39 @@ a:focus,
 .text_dark .second_col,
 .text_dark .mainfooter {
     background: var(--chakra-colors-gray-100);
+}
+
+.text_dark .hero_btns .chat.calendar_btn {
+    color: var(--chakra-colors-blue-600);
+    border-color: var(--chakra-colors-blue-600);
+    background: transparent;
+}
+
+.text_dark .hero_btns .chat.calendar_btn:hover {
+    background: var(--chakra-colors-blue-600);
+    color: #fff;
+}
+
+.text_dark .github_activity_title {
+    color: var(--chakra-colors-gray-800);
+}
+
+.text_dark .github_stat_card {
+    background: rgba(0, 0, 0, 0.03);
+    border-color: rgba(0, 0, 0, 0.08);
+}
+
+.text_dark .github_stat_card:hover {
+    background: rgba(0, 0, 0, 0.06);
+    border-color: rgba(3, 102, 214, 0.3);
+}
+
+.text_dark .github_stat_value {
+    color: #0366d6;
+}
+
+.text_dark .github_stat_label {
+    color: var(--chakra-colors-gray-600);
 }
 
 .text_dark .switch_panel {

--- a/src/Layout/App.jsx
+++ b/src/Layout/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState, lazy, Suspense } from "react";
 import { BrowserRouter, Routes, Route, Link, Navigate } from "react-router";
 import Footer from "../compnents/Footer";
+import GitHubActivity from "../compnents/GitHubActivity";
 import Home from "../pages/Home";
 import "./App.css";
 import "bootstrap/dist/css/bootstrap.min.css";
@@ -70,6 +71,7 @@ const App = () => {
           </Routes>
         </Suspense>
 
+        <GitHubActivity isMode={isMode} />
         <Footer />
       </div>
     </BrowserRouter>

--- a/src/compnents/GitHubActivity.jsx
+++ b/src/compnents/GitHubActivity.jsx
@@ -1,0 +1,89 @@
+import React, { useRef, useState, useCallback } from 'react';
+import { GitHubCalendar } from 'react-github-calendar';
+import "../Layout/App.css";
+
+const GitHubActivity = ({ isMode }) => {
+    const [stats, setStats] = useState({ total: 0, currentStreak: 0, longestStreak: 0 });
+    const hasComputed = useRef(false);
+
+    const theme = {
+        dark: ['#161b22', '#0a3d62', '#1e6ea1', '#3498db', '#58a6ff'],
+        light: ['#ebedf0', '#b6d7f8', '#79b8ff', '#2188ff', '#0366d6'],
+    };
+
+    const computeStats = useCallback((contributions) => {
+        if (hasComputed.current) return contributions;
+        hasComputed.current = true;
+
+        const total = contributions.reduce((sum, day) => sum + day.count, 0);
+
+        const sorted = [...contributions].sort((a, b) => b.date.localeCompare(a.date));
+        let currentStreak = 0;
+        for (const day of sorted) {
+            if (day.count > 0) currentStreak++;
+            else break;
+        }
+
+        let longestStreak = 0;
+        let streak = 0;
+        const chronological = [...contributions].sort((a, b) => a.date.localeCompare(b.date));
+        for (const day of chronological) {
+            if (day.count > 0) {
+                streak++;
+                longestStreak = Math.max(longestStreak, streak);
+            } else {
+                streak = 0;
+            }
+        }
+
+        setStats({ total, currentStreak, longestStreak });
+        return contributions;
+    }, []);
+
+    return (
+        <section className="github_activity_section">
+            <div className="container-lg px-5">
+                <h2 className="github_activity_title">GitHub Activity</h2>
+                <div className="github_stats_row">
+                    <div className="github_stat_card">
+                        <span className="github_stat_value">{stats.total}</span>
+                        <span className="github_stat_label">Contributions</span>
+                    </div>
+                    <div className="github_stat_card">
+                        <span className="github_stat_value">{stats.currentStreak}</span>
+                        <span className="github_stat_label">Current Streak</span>
+                    </div>
+                    <div className="github_stat_card">
+                        <span className="github_stat_value">{stats.longestStreak}</span>
+                        <span className="github_stat_label">Longest Streak</span>
+                    </div>
+                </div>
+                <div className="github_calendar_wrapper">
+                    <GitHubCalendar
+                        username="iamsheraz"
+                        colorScheme={isMode ? "dark" : "light"}
+                        theme={theme}
+                        blockSize={13}
+                        blockMargin={4}
+                        blockRadius={3}
+                        fontSize={13}
+                        showWeekdayLabels
+                        transformData={computeStats}
+                        errorMessage="Unable to load GitHub activity"
+                        labels={{
+                            totalCount: '{{count}} contributions in the last year',
+                        }}
+                        tooltips={{
+                            activity: {
+                                text: (activity) =>
+                                    `${activity.count} contribution${activity.count !== 1 ? 's' : ''} on ${new Date(activity.date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`,
+                            },
+                        }}
+                    />
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default GitHubActivity;

--- a/src/compnents/about.jsx
+++ b/src/compnents/about.jsx
@@ -21,13 +21,15 @@ const About = (props) => {
                                 In addition to my professional skills, I'm an individual who thrives on positivity and embraces challenges. I pay keen attention to detail and hold personal growth in the highest regard. My past roles, as reflected in my resume, have taught me the importance of these traits in the tech industry.
                             </p>
                             <p>
-                                There is much more to my journey and experiences that I would love to share. I'm excited about discussing potential internship opportunities that could benefit from my skills and passion. Even if a formal opportunity doesn't exist, I am eager to explore possibilities. Let's start the conversation!
+                                There is much more to my journey and experiences that I would love to share. I'm excited about discussing potential opportunities that could benefit from my skills and passion. Even if a formal opportunity doesn't exist, I am eager to explore possibilities. Schedule a free 30-minute call, or reach out anytime.
                             </p>
                             <div className="hero_btns pt-2 mt-4 d-flex align-items-center">
                                 <a href="mailto:hiresheraz@gmail.com" className="chat">
                                     Let's get in touch!
                                 </a>
-
+                                <a href="https://calendly.com/hiresheraz/30min" target="_blank" rel="noopener noreferrer" className="chat calendar_btn ms-3" aria-label="Book a 30-minute call on Calendly (opens in new tab)">
+                                    Schedule a 30-Min Call
+                                </a>
                                 <ResumeDropdown id="resume-dropdown-about" />
                             </div>
                         </div>

--- a/src/compnents/all-sec.jsx
+++ b/src/compnents/all-sec.jsx
@@ -335,13 +335,15 @@ const WholeWrapper = (props) => {
                                         As a Java Full Stack Developer, my foremost passion lies in creating robust and effective software solutions. This role allows me to construct across the broad spectrum of engineering, design, and business, capitalizing on my skills and interests.
                                     </p>
                                     <p>
-                                        With over six years of professional experience, I have a wealth of knowledge to share and am eager to embrace new challenges. I am particularly interested in exploring opportunities where I can apply my technical prowess and product-oriented mindset to foster growth and innovation. Even if a formal opportunity does not currently exist, I am open to discussion and potential collaboration. Let's start the conversation!
+                                        With over six years of professional experience, I have a wealth of knowledge to share and am eager to embrace new challenges. I am particularly interested in exploring opportunities where I can apply my technical prowess and product-oriented mindset to foster growth and innovation. Even if a formal opportunity does not currently exist, I am open to discussion and potential collaboration. Schedule a free 30-minute call to discuss your project, or drop me a line anytime.
                                     </p>
                                     <div className="hero_btns pt-2 mt-4 d-flex align-items-center">
                                         <a href="mailto:hiresheraz@gmail.com" className="chat">
                                             Let's get in touch!
                                         </a>
-
+                                        <a href="https://calendly.com/hiresheraz/30min" target="_blank" rel="noopener noreferrer" className="chat calendar_btn ms-3" aria-label="Book a 30-minute call on Calendly (opens in new tab)">
+                                            Schedule a 30-Min Call
+                                        </a>
                                         <ResumeDropdown id="resume-dropdown-tldr" />
                                     </div>
                                 </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -29,7 +29,9 @@ const Home = () => {
               <Link to="/chat" className="chat">
                 Let's Chat!
               </Link>
-
+              <a href="https://calendly.com/hiresheraz/30min" target="_blank" rel="noopener noreferrer" className="chat calendar_btn ms-3" aria-label="Book a 30-minute call on Calendly (opens in new tab)">
+                Book a Call
+              </a>
               <ResumeDropdown id="resume-dropdown-hero" />
             </div>
           </div>


### PR DESCRIPTION
Move GitHub activity heatmap from footer into a dedicated section with contribution stats (total, current streak, longest streak), custom blue theme, tooltips, and responsive stat cards. Add Book a Call button to the hero for high-intent visitors. Update conclusion sections with more descriptive scheduling CTA copy.