### PR TITLE
fix: Make chat page mobile-friendly with dvh and safe area insets

### DIFF
--- a/src/Layout/App.css
+++ b/src/Layout/App.css
@@ -1742,7 +1742,7 @@ a:focus,
 /* ==================== */
 
 .chat_page {
-    height: 100vh;
+    height: 100dvh;
     display: flex;
     flex-direction: column;
     padding-top: 80px;
@@ -2863,29 +2863,124 @@ a:focus,
 
 /* Chat Page Responsive */
 @media (max-width: 768px) {
+    .chat_page {
+        padding-top: 70px;
+        padding-bottom: env(safe-area-inset-bottom, 0px);
+    }
+
     .chat_container {
         padding: 0 0.75rem;
     }
 
     .chat_bubble {
-        max-width: 85%;
+        max-width: 90%;
+        padding: 0.75rem 1rem;
+        font-size: 0.9rem;
     }
 
     .chat_welcome {
-        padding: 2rem 0.5rem;
+        padding: 1.5rem 0.5rem;
+    }
+
+    .chat_welcome_emoji {
+        font-size: 2.25rem;
     }
 
     .chat_welcome_title {
         font-size: var(--chakra-fontSizes-xl);
     }
 
+    .chat_welcome_text {
+        font-size: 0.85rem;
+        margin-bottom: 1.25rem;
+    }
+
     .chat_welcome_choices {
         flex-direction: column;
+        gap: 0.75rem;
+        max-width: 100%;
+    }
+
+    .chat_welcome_choice_btn {
+        padding: 1rem 0.75rem;
+    }
+
+    .chat_suggestions_list {
+        gap: 0.4rem;
+    }
+
+    .chat_suggestion_chip {
+        padding: 0.4rem 0.75rem;
+        font-size: 0.8rem;
+    }
+
+    .chat_easter_hint {
+        margin-top: 1rem;
+    }
+
+    .chat_input_form {
+        gap: 0.5rem;
+        padding: 0.75rem 0;
+        padding-bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
+    }
+
+    .chat_input {
+        font-size: 16px; /* prevents iOS zoom on focus */
+        padding: 0.625rem 0.875rem;
+        border-radius: 10px;
+    }
+
+    .chat_send_btn {
+        width: 40px;
+        height: 40px;
+        border-radius: 10px;
+    }
+
+    .chat_header {
+        padding: 0.75rem 0;
+    }
+
+    .chat_header_avatar {
+        width: 32px;
+        height: 32px;
+    }
+
+    .chat_messages {
+        padding: 1rem 0;
+        gap: 0.75rem;
+    }
+
+    .chat_followups {
+        gap: 0.4rem;
+    }
+
+    .chat_followup_chip {
+        padding: 0.35rem 0.7rem;
+        font-size: 0.75rem;
     }
 
     .chat_badge_toast {
         bottom: 1rem;
         right: 1rem;
         left: 1rem;
+    }
+
+    .chat_slash_menu {
+        border-radius: 10px;
+    }
+}
+
+@media (max-width: 400px) {
+    .chat_welcome_title {
+        font-size: var(--chakra-fontSizes-lg);
+    }
+
+    .chat_welcome_text {
+        font-size: 0.8rem;
+    }
+
+    .chat_suggestion_chip {
+        padding: 0.35rem 0.6rem;
+        font-size: 0.75rem;
     }
 }


### PR DESCRIPTION
Use 100dvh instead of 100vh to account for mobile browser chrome, add safe-area-inset-bottom for iOS home indicator, prevent iOS auto-zoom with 16px input font-size, and add comprehensive mobile responsive styles for all chat page elements.